### PR TITLE
Implement subscription view and updated player controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,30 +71,27 @@
       border-radius: 4px;
       display: none;
     }
-    #fullscreen_button {
-      margin-top: 10px;
-      padding: 6px 10px;
-      font-size: 14px;
-      cursor: pointer;
+    #player {
+      width: 100%;
+      height: 70vh;
     }
   </style>
 </head>
 <body>
   <nav id="sidebar">
     <div id="toggleSidebar">☰</div>
+    <button id="nav_subscriptions">Subscriptions</button>
     <button id="nav_player">Player</button>
     <button id="nav_subs">Manage Subs</button>
     <button id="nav_search">Search</button>
-    <button id="nav_recommended">Recommended</button>
   </nav>
   <div id="main">
     <div id="signin">
       <button id="authorize_button">Authorize</button>
     </div>
-    <div id="player_view" class="view active">
+    <div id="player_view" class="view">
       <div id="player"></div>
       <div id="speedOverlay"></div>
-      <button id="fullscreen_button">Full Screen</button>
     </div>
     <div id="subs_view" class="view">
       <table id="subs_table">
@@ -123,9 +120,9 @@
         <tbody></tbody>
       </table>
     </div>
-    <div id="recommended_view" class="view">
-      <button id="load_recommended">Load Recommended</button>
-      <table id="recommended_table">
+    <div id="subscriptions_view" class="view active">
+      <button id="load_subscriptions">Load Subscriptions</button>
+      <table id="subscriptions_table">
         <thead>
           <tr>
             <th>Channel Name</th>
@@ -134,12 +131,13 @@
             <th>Video Date</th>
             <th>Views</th>
             <th>Likes</th>
-            <th>Dislikes</th>
+            <th>Transcript</th>
             <th>Total Comments</th>
           </tr>
         </thead>
         <tbody></tbody>
       </table>
+      <button id="show_more_subs">Show more</button>
     </div>
   </div>
   <script src="https://apis.google.com/js/api.js"></script>

--- a/plan.md
+++ b/plan.md
@@ -126,39 +126,39 @@ This plan outlines building a unified single-page application with a collapsible
 
 The following tasks describe how Codex should update the application to satisfy the new feature requests.
 
-1. **Refactor Project Structure**
+1. **Refactor Project Structure** [ ]
    - Break `script.js` into logical modules (authentication, API calls, player controls, UI handlers).
    - Move styling into dedicated CSS files and organize them in a `styles/` directory. Consider using a CSS framework (e.g., Tailwind or Bootstrap) compiled with a build tool.
    - Introduce `npm` with a minimal bundler (like Vite or Webpack) for development and hot reload.
 
-2. **UI/UX Enhancements**
+2. **UI/UX Enhancements** [ ]
    - Apply modern design practices using the chosen CSS framework to improve layout and responsiveness.
    - Keep the sidebar collapse/expand functionality but ensure that when collapsed only a small icon is visible.
 
-3. **Default View and Navigation Update**
+3. **Default View and Navigation Update** [x]
    - Rename the "Recommended" page to **Subscriptions** and list it first in the sidebar.
    - When the app starts, automatically show this page instead of the player.
 
-4. **Incremental Video Loading**
+4. **Incremental Video Loading** [x]
    - Fetch videos from each subscribed channel in 3‑day windows starting from today.
    - Display a **Show more** button at the bottom that loads the next three days of results and appends them to the table.
 
-5. **Authentication Flow**
+5. **Authentication Flow** [ ]
    - Remove the manual **Authorize** button.
    - Detect when no OAuth token is present or when a request fails due to authentication and automatically initiate the sign‑in flow.
 
-6. **Player Updates**
+6. **Player Updates** [x]
    - Remove the Full Screen button and associated logic.
    - Allow the player element to grow vertically so the video uses the available height.
    - Update keyboard shortcuts:
      - Reverse `A` and `S` behaviors ("A" decreases speed, "S" increases).
      - Arrow keys: Up/Down adjust speed ±0.25x with overlay, Left rewinds 5s, Right forwards 5s.
 
-7. **Subscriptions Table Changes**
+7. **Subscriptions Table Changes** [x]
    - Replace the Dislikes column with a Transcript column.
    - Add a button that attempts to download the video's transcript via the YouTube Captions API.
 
-8. **Testing and Validation**
+8. **Testing and Validation** [ ]
    - After restructuring, ensure existing features still work: managing subscriptions, search, and playback.
    - Add checks for incremental loading and new keyboard shortcuts.
 


### PR DESCRIPTION
## Summary
- default page is now subscription videos
- allow fetching videos in 3-day windows with a **Show more** button
- rename Recommended to Subscriptions in navigation
- remove fullscreen button and update keyboard shortcuts
- add transcript button in subscriptions table
- check off completed tasks in `plan.md`

## Testing
- `npm test` *(fails: could not find package.json)*
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_686a445ef3c883259af617ab424297c0